### PR TITLE
Use lib.cleanSource in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import ../../arduino.nix { # path to arduino.nix from this repository
   board = board; # board name, added to the name
   # in this case it is from the command line, but you can also set it here
   libraries = []; # libraries from arduino-core, valid names below
-  src = ./.; # path to the arduino files, passed to the derivation
+  src = pkgs.lib.cleanSource ./.; # path to the arduino files, passed to the derivation
 }
 ```
 

--- a/examples/blink/default.nix
+++ b/examples/blink/default.nix
@@ -4,5 +4,5 @@ import ../../arduino.nix { inherit (pkgs) stdenv lib arduino-mk writeScript ardu
   name = "blink";
   board = board;
   libraries = [];
-  src = ./.;
+  src = pkgs.lib.cleanSource ./.;
 }

--- a/examples/servo/default.nix
+++ b/examples/servo/default.nix
@@ -4,5 +4,5 @@ import ../../arduino.nix { inherit (pkgs) stdenv lib arduino-mk writeScript ardu
   name = "sweep";
   board = board;
   libraries = ["Servo"];
-  src = ./.;
+  src = pkgs.lib.cleanSource ./.;
 }


### PR DESCRIPTION
This allows, for example, multiple repeated builds in the same source directory because symlinks like `result` will be ignored.

More info on this function is here: https://github.com/NixOS/nixpkgs/blob/20.09/lib/sources.nix#L36