### PR TITLE
Two small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Create a nix file that looks something like this:
 ```nix
 { board, pkgs ? import <nixpkgs> {} }:
 
-import ../../arduino.nix { # path to arduino.nix from this repository
-    inherit (pkgs) stdenv lib arduino-mk writeScript arduino-core-unwrapped;
-  } {
+pkgs.callPackage ../../arduino.nix { } { # path to arduino.nix from this repository
   name = "blink"; # name you want for the derivation
   board = board; # board name, added to the name
   # in this case it is from the command line, but you can also set it here

--- a/arduino.nix
+++ b/arduino.nix
@@ -19,8 +19,10 @@ in stdenv.mkDerivation({
     include ${arduino-mk}/Arduino.mk
   '').outPath;
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     mv build-*/*_.hex $out/build.hex
+    runHook postInstall
   '';
   name = "${name}-${board}";
 } // extraArgs)

--- a/examples/blink/default.nix
+++ b/examples/blink/default.nix
@@ -1,6 +1,6 @@
 { board, pkgs ? import <nixpkgs> {} }:
 
-import ../../arduino.nix { inherit (pkgs) stdenv lib arduino-mk writeScript arduino-core-unwrapped; } {
+pkgs.callPackage ../../arduino.nix { } {
   name = "blink";
   board = board;
   libraries = [];

--- a/examples/servo/default.nix
+++ b/examples/servo/default.nix
@@ -1,6 +1,6 @@
 { board, pkgs ? import <nixpkgs> {} }:
 
-import ../../arduino.nix { inherit (pkgs) stdenv lib arduino-mk writeScript arduino-core-unwrapped; } {
+pkgs.callPackage ../../arduino.nix { } {
   name = "sweep";
   board = board;
   libraries = ["Servo"];


### PR DESCRIPTION
1. Run installPhase hooks

2. Demonstrate usage of `callPackage` in examples

This allows users of the package to not needing to know what arguments
the derivation is expecting.